### PR TITLE
Update spacepy version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.14.5
 tqdm==4.19.8
 h5py==2.7.1
-spacepy==0.1.6
+spacepy==0.2.3
 requests==2.20.0


### PR DESCRIPTION
Solves: "ModuleNotFoundError: No module named 'setuptools.command.bdist_wininst'" when installing spacepy in the provided docker container.
See also: https://github.com/spacepy/spacepy/issues/530